### PR TITLE
refactor(web): BrandMark 공통화 및 ping 모션 복원

### DIFF
--- a/apps/web/src/app/(public)/_components/PublicHeader.tsx
+++ b/apps/web/src/app/(public)/_components/PublicHeader.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from 'next-intl';
 
 import { ArrowLeft } from 'lucide-react';
 
+import { BrandMark } from '@/components/BrandMark';
 import { Button } from '@/components/ui/button';
 import { LangToggle } from '@/components/landing/LangToggle';
 import { MobileMenu } from '@/components/landing/MobileMenu';
@@ -84,15 +85,10 @@ export function PublicHeader({ lang, variant: variantProp }: PublicHeaderProps):
         <div className='flex min-h-10 items-center gap-2'>
           <Link
             href={buildPublicPath(lang, '')}
-            className='flex items-center gap-2.5 rounded-md text-foreground outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+            className='group flex items-center gap-2.5 rounded-md text-foreground outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background'
             aria-label={tCommon('brand')}
           >
-            <span
-              className='flex size-9 shrink-0 items-center justify-center rounded-full bg-primary transition-transform hover:scale-105'
-              aria-hidden
-            >
-              <span className='size-2 rounded-full bg-primary-foreground' />
-            </span>
+            <BrandMark className='transition-transform group-hover:scale-105' />
             <span className='hidden text-sm font-semibold tracking-tight text-foreground sm:inline md:text-base'>
               {tCommon('brand')}
             </span>

--- a/apps/web/src/app/admin/_components/AdminSidebar.tsx
+++ b/apps/web/src/app/admin/_components/AdminSidebar.tsx
@@ -29,6 +29,7 @@ import {
   Users,
 } from 'lucide-react';
 
+import { BrandMark } from '@/components/BrandMark';
 import { ThemeToggle } from '@/components/landing/ThemeToggle';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
@@ -169,12 +170,7 @@ export function AdminSidebar({ userName }: AdminSidebarProps) {
             className='mb-4 flex shrink-0 items-center gap-2.5 rounded-md px-3 py-2 text-sidebar-foreground outline-none transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:ring-offset-2 focus-visible:ring-offset-sidebar'
             aria-label='Home'
           >
-            <span
-              className='flex size-9 shrink-0 items-center justify-center rounded-full bg-sidebar-primary'
-              aria-hidden
-            >
-              <span className='size-2 rounded-full bg-sidebar-primary-foreground' />
-            </span>
+            <BrandMark variant='sidebar' />
             <span className='text-sm font-semibold tracking-tight'>Admin</span>
           </Link>
           <div className='min-h-0 flex-1 overflow-y-auto'>{navLinks}</div>
@@ -189,9 +185,7 @@ export function AdminSidebar({ userName }: AdminSidebarProps) {
           className='flex items-center gap-2 rounded-md text-foreground outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2'
           aria-label='Home'
         >
-          <span className='flex size-8 items-center justify-center rounded-full bg-primary'>
-            <span className='size-1.5 rounded-full bg-primary-foreground' />
-          </span>
+          <BrandMark size='sm' dotSize='sm' />
           <span className='text-sm font-semibold'>Admin</span>
         </Link>
         <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -11,6 +11,7 @@ import { Home, LogOut, Menu, Settings, User } from 'lucide-react';
 
 import { LangToggle } from '@/components/landing/LangToggle';
 import { ThemeToggle } from '@/components/landing/ThemeToggle';
+import { BrandMark } from '@/components/BrandMark';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import type { Locale } from '@workspace/shared/i18n';
@@ -39,9 +40,7 @@ export function AppHeader({ userName, isAdmin, locale }: AppHeaderProps): React.
         {/* 좌측: 로고 + 데스크톱 네비게이션 */}
         <div className='flex items-center gap-6'>
           <Link href='/dashboard' className='flex items-center gap-2'>
-            <span className='flex size-8 items-center justify-center rounded-full bg-primary'>
-              <span className='size-2 rounded-full bg-primary-foreground animate-ping' />
-            </span>
+            <BrandMark size='sm' dotSize='md' />
             <span className='text-sm font-semibold tracking-wide text-foreground md:text-base'>{t('brand')}</span>
           </Link>
 

--- a/apps/web/src/components/BrandMark.tsx
+++ b/apps/web/src/components/BrandMark.tsx
@@ -1,0 +1,66 @@
+import type { ComponentProps } from 'react';
+
+import { cn } from '@/lib/utils';
+
+type BrandMarkSize = 'sm' | 'md';
+type BrandMarkDotSize = 'sm' | 'md';
+type BrandMarkVariant = 'default' | 'sidebar';
+
+interface BrandMarkProps extends Omit<ComponentProps<'span'>, 'children'> {
+  size?: BrandMarkSize;
+  dotSize?: BrandMarkDotSize;
+  variant?: BrandMarkVariant;
+  animated?: boolean;
+}
+
+const outerSizeClass: Record<BrandMarkSize, string> = {
+  sm: 'size-8',
+  md: 'size-9',
+};
+
+const dotSizeClass: Record<BrandMarkDotSize, string> = {
+  sm: 'size-1.5',
+  md: 'size-2',
+};
+
+const variantClass: Record<BrandMarkVariant, { outer: string; dot: string }> = {
+  default: {
+    outer: 'bg-primary',
+    dot: 'bg-primary-foreground',
+  },
+  sidebar: {
+    outer: 'bg-sidebar-primary',
+    dot: 'bg-sidebar-primary-foreground',
+  },
+};
+
+export function BrandMark({
+  size = 'md',
+  dotSize = 'md',
+  variant = 'default',
+  animated = true,
+  className,
+  ...props
+}: BrandMarkProps): React.ReactElement {
+  const colors = variantClass[variant];
+
+  return (
+    <span
+      className={cn('relative inline-flex shrink-0', outerSizeClass[size], className)}
+      aria-hidden='true'
+      {...props}
+    >
+      <span className={cn('relative flex size-full items-center justify-center rounded-full', colors.outer)}>
+        {animated ? (
+          <span
+            className={cn(
+              'pointer-events-none absolute inset-0 rounded-full opacity-25 motion-safe:animate-ping',
+              colors.outer,
+            )}
+          />
+        ) : null}
+        <span className={cn('relative z-10 rounded-full', dotSizeClass[dotSize], colors.dot)} />
+      </span>
+    </span>
+  );
+}


### PR DESCRIPTION
## 변경 내용
- 노란 원과 중앙 점으로 구성된 브랜드 아이콘을 공통 `BrandMark` 컴포넌트로 분리했습니다.
- 퍼블릭 헤더, 로그인/회원가입 헤더, 앱 헤더, 어드민 사이드바가 동일한 `BrandMark`를 사용하도록 정리했습니다.
- `BrandMark`의 기본 동작으로 초기 등대형 `ping` 애니메이션을 복원했습니다.
- 중앙 점은 고정하고, 바깥 원만 `motion-safe:animate-ping`으로 깜빡이도록 맞췄습니다.

## 변경 이유
화면마다 브랜드 아이콘의 마크업과 애니메이션 방식이 달라지고 있어서, 한 곳에서 구조와 모션을 함께 관리하도록 정리할 필요가 있었습니다. 이번 변경으로 브랜드 아이콘의 형태와 동작을 공통 컴포넌트로 통일했습니다.

## 영향 범위
- 공개 화면과 로그인 후 화면에서 브랜드 아이콘이 같은 구조와 모션으로 보입니다.
- `prefers-reduced-motion` 환경에서는 동일한 DOM 구조를 유지하면서 애니메이션만 비활성화됩니다.
- 이후 아이콘 디자인이나 모션 조정은 `BrandMark` 한 곳에서 처리할 수 있습니다.

## 검증
- `pnpm --filter @workspace/web lint`
- `pnpm --filter @workspace/web typecheck`
- Playwright로 `/ko`, `/login`, 인증 후 `/dashboard`에서 `BrandMark` DOM 및 `ping` 애니메이션 확인
- Playwright로 reduced motion 환경에서 애니메이션 비활성화 확인

## 참고
- 로컬 `/.claude/` 설정 파일은 PR 범위에서 제외했습니다.
- `/admin` 경로 자체는 현재 404이며, 어드민 사이드바의 `BrandMark` 사용 여부는 소스 기준으로 확인했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 여러 페이지의 브랜드 마크 UI를 새로운 재사용 가능한 컴포넌트로 통합했습니다.
  * 기존의 인라인 마크업을 표준화된 컴포넌트로 대체하여 코드 일관성을 개선했습니다.
  * 호버 애니메이션 및 시각적 동작은 유지되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->